### PR TITLE
Missing comma in JSON example

### DIFF
--- a/doc/JSONY.swim
+++ b/doc/JSONY.swim
@@ -61,7 +61,7 @@ square brackets.
 
   [
     [ "array", "of", 4, "scalars" ],
-    [ "array", "with", [ "sub", "array" { "of": "things" } ] ],
+    [ "array", "with", [ "sub", "array", { "of": "things" } ] ],
     [ "array", "of", 7, "things", "on", "two", "lines" ]
   ]
 


### PR DESCRIPTION
I assume this comma is required.  If not, disregard. :)
