### PR TITLE
Removed errant trailing space from example result

### DIFF
--- a/ReadMe.pod
+++ b/ReadMe.pod
@@ -50,7 +50,7 @@ Strings with spaces can use single or double quotes:
     # More commenting
     "baz  boom "
 
-    [ "foo bar ", "baz  boom " ]
+    [ "foo bar", "baz  boom " ]
 
 Top level hashes can be ':' separated pairs or use curlies. Sub hashes
 require curlies.


### PR DESCRIPTION
Removed a trailing space on the first part of the "Strings with spaces" example result which didn't match the input, which lacks any trailing spaces.